### PR TITLE
Update image so it works on pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install airflow-provider-hex
 After creating a Hex API token, set up your Airflow Connection Credentials in the Airflow
 UI.
 
-![Connection Setup](/docs/hex-connection-setup.png)
+![Connection Setup](https://raw.githubusercontent.com/hex-inc/airflow-provider-hex/main/docs/hex-connection-setup.png)
 
 * Connection ID: `hex_default`
 * Connection Type: `Hex Connection`


### PR DESCRIPTION
The [pypi docs](https://pypi.org/project/airflow-provider-hex/) for the image are broken. [Stack overflow says to use the raw image](https://stackoverflow.com/questions/41983209/how-do-i-add-images-to-a-pypi-readme-that-works-on-github)