### PR TITLE
fix: log full API response payload on 4xx/5xx errors

### DIFF
--- a/airflow_provider_hex/hooks/hex.py
+++ b/airflow_provider_hex/hooks/hex.py
@@ -110,6 +110,13 @@ class HexHook(BaseHook):
         prepped_request = session.prepare_request(req)
         self.log.info("Sending '%s' to url: %s", method, url)
         response = session.send(prepped_request)
+
+        # raise_for_status doesn't provide enough detail on error payload in traceback
+        if response.status_code != requests.codes.ok:
+            self.log.error(
+                f"Received status code {response.status_code}: {response.text}"
+            )
+
         response.raise_for_status()
 
         if response.headers.get("Content-Type", "").startswith("application/json"):


### PR DESCRIPTION
requests.raise_for_status() only provides a generic error reason in the traceback when you get hit with a non-200 response, for example:

```
File "/usr/local/lib/python3.12/site-packages/requests/models.py", line
1024, in raise_for_status

    raise HTTPError(http_error_msg, response=self)

requests.exceptions.HTTPError: 422 Client Error: Unprocessable Entity
for url: https://app.hex.tech/api/v1/project/uuid-here/run
```

The full response payload should also be logged so that users can easily debug the reason why an API request failed:

```
{"reason":"Slack notifications cannot be sent. The user has not enabled
notifications for Slack. Please enable it in Notifications
settings.","traceId":"xxxx"}
```